### PR TITLE
Update community/sway/usr/share/sway/templates/waybar/config.jsonc

### DIFF
--- a/community/sway/usr/share/sway/templates/waybar/config.jsonc
+++ b/community/sway/usr/share/sway/templates/waybar/config.jsonc
@@ -240,7 +240,7 @@
         "return-type": "json",
         "format": " {}",
         "exec": "gh api '/notifications' -q '{ text: length }' | cat -",
-        "exec-if": "[ -x \"$(command -v gh)\" ] && gh auth status 2>&1 | grep -q -m 1 'Logged in' && gh api '/notifications' -q 'length' | grep -q -m 1 '0' ; test $? -eq 1",
+        "exec-if": "[ -x \"$(command -v gh)\" ] && gh auth status 2>&1 | grep -q -m 1 'Logged in' && test $(gh api '/notifications' -q 'length') -ne 0",
         "on-click": "xdg-open https://github.com/notifications && sleep 30 && pkill -RTMIN+4 waybar",
         "signal": 4
     },


### PR DESCRIPTION
Currently whenever you have a notification amount containing a `0` the `exec-if` evaluates as false. so if you have `10` or `20` notifications. This changes tests whether we have a length of `0`. 